### PR TITLE
Add initial read of subscriber variables

### DIFF
--- a/NetShrVarApp/src/NetShrVarInterface.h
+++ b/NetShrVarApp/src/NetShrVarInterface.h
@@ -84,6 +84,7 @@ private:
 	void updateParamCNV (int param_index, CNVData data, bool do_asyn_param_callbacks);
 	template<CNVDataType cnvType> void updateParamCNVImpl(int param_index, CNVData data, CNVDataType type, unsigned int nDims, bool do_asyn_param_callbacks);
 	template<typename T,typename U> void updateParamArrayValueImpl(int param_index, T* val, size_t nElements);
+	void readVarInit(NvItem* item, CallbackData* cb_data);
 };
 
 #endif /* NETSHRVAR_INTERFACE_H */


### PR DESCRIPTION
This adds an initial read of a subscriber shared variable connections, otherwise EPICS process variable is left in an uninitialised state until the first value change. Should fix #2 
